### PR TITLE
Remove "register" keyword from PRNG

### DIFF
--- a/src/utils/MersenneTwister.h
+++ b/src/utils/MersenneTwister.h
@@ -172,9 +172,9 @@ inline void MTRand::initialize( const uint32 seed )
 	// See Knuth TAOCP Vol 2, 3rd Ed, p.106 for multiplier.
 	// In previous versions, most significant bits (MSBs) of the seed affect
 	// only MSBs of the state array.  Modified 9 Jan 2002 by Makoto Matsumoto.
-	register uint32 *s = state;
-	register uint32 *r = state;
-	register int i = 1;
+	uint32 *s = state;
+	uint32 *r = state;
+	int i = 1;
 	*s++ = seed & 0xffffffffUL;
 	for( ; i < N; ++i )
 	{
@@ -188,8 +188,8 @@ inline void MTRand::reload()
 	// Generate N new values in state
 	// Made clearer and faster by Matthew Bellew (matthew.bellew@home.com)
 	static const int MmN = int(M) - int(N);  // in case enums are unsigned
-	register uint32 *p = state;
-	register int i;
+	uint32 *p = state;
+	int i;
 	for( i = N - M; i--; ++p )
 		*p = twist( p[M], p[0], p[1] );
 	for( i = M; --i; ++p )
@@ -215,9 +215,9 @@ inline void MTRand::seed( uint32 *const bigSeed, const uint32 seedLength )
 	// in each element are discarded.
 	// Just call seed() if you want to get array from /dev/urandom
 	initialize(19650218UL);
-	register int i = 1;
-	register uint32 j = 0;
-	register int k = ( N > seedLength ? N : seedLength );
+	int i = 1;
+	uint32 j = 0;
+	int k = ( N > seedLength ? N : seedLength );
 	for( ; k; --k )
 	{
 		state[i] =
@@ -251,9 +251,9 @@ inline void MTRand::seed()
 	if( urandom )
 	{
 		uint32 bigSeed[N];
-		register uint32 *s = bigSeed;
-		register int i = N;
-		register bool success = true;
+		uint32 *s = bigSeed;
+		int i = N;
+		bool success = true;
 		while( success && i-- )
 			success = fread( s++, sizeof(uint32), 1, urandom );
 		fclose(urandom);
@@ -275,9 +275,9 @@ inline MTRand::MTRand()
 
 inline MTRand::MTRand( const MTRand& o )
 {
-	register const uint32 *t = o.state;
-	register uint32 *s = state;
-	register int i = N;
+	const uint32 *t = o.state;
+	uint32 *s = state;
+	int i = N;
 	for( ; i--; *s++ = *t++ ) {}
 	left = o.left;
 	pNext = &state[N-left];
@@ -291,7 +291,7 @@ inline MTRand::uint32 MTRand::randInt()
 	if( left == 0 ) reload();
 	--left;
 
-	register uint32 s1;
+	uint32 s1;
 	s1 = *pNext++;
 	s1 ^= (s1 >> 11);
 	s1 ^= (s1 <<  7) & 0x9d2c5680UL;
@@ -365,18 +365,18 @@ inline double MTRand::operator()()
 
 inline void MTRand::save( uint32* saveArray ) const
 {
-	register const uint32 *s = state;
-	register uint32 *sa = saveArray;
-	register int i = N;
+	const uint32 *s = state;
+	uint32 *sa = saveArray;
+	int i = N;
 	for( ; i--; *sa++ = *s++ ) {}
 	*sa = left;
 }
 
 inline void MTRand::load( uint32 *const loadArray )
 {
-	register uint32 *s = state;
-	register uint32 *la = loadArray;
-	register int i = N;
+	uint32 *s = state;
+	uint32 *la = loadArray;
+	int i = N;
 	for( ; i--; *s++ = *la++ ) {}
 	left = *la;
 	pNext = &state[N-left];
@@ -384,16 +384,16 @@ inline void MTRand::load( uint32 *const loadArray )
 
 inline std::ostream& operator<<( std::ostream& os, const MTRand& mtrand )
 {
-	register const MTRand::uint32 *s = mtrand.state;
-	register int i = mtrand.N;
+	const MTRand::uint32 *s = mtrand.state;
+	int i = mtrand.N;
 	for( ; i--; os << *s++ << "\t" ) {}
 	return os << mtrand.left;
 }
 
 inline std::istream& operator>>( std::istream& is, MTRand& mtrand )
 {
-	register MTRand::uint32 *s = mtrand.state;
-	register int i = mtrand.N;
+	MTRand::uint32 *s = mtrand.state;
+	int i = mtrand.N;
 	for( ; i--; is >> *s++ ) {}
 	is >> mtrand.left;
 	mtrand.pNext = &mtrand.state[mtrand.N-mtrand.left];
@@ -403,9 +403,9 @@ inline std::istream& operator>>( std::istream& is, MTRand& mtrand )
 inline MTRand& MTRand::operator=( const MTRand& o )
 {
 	if( this == &o ) return (*this);
-	register const uint32 *t = o.state;
-	register uint32 *s = state;
-	register int i = N;
+	const uint32 *t = o.state;
+	uint32 *s = state;
+	int i = N;
 	for( ; i--; *s++ = *t++ ) {}
 	left = o.left;
 	pNext = &state[N-left];


### PR DESCRIPTION
The `register` keyword was deprecated in C++11 and removed in C++17. Since the keyword has never really done anything, this PR shouldn't affect speed at all and prunes away lots of compiler warnings (errors in C++17) without any effort.